### PR TITLE
Use EventRegistry for news headlines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@ TWITTER_API_KEY=your_api_key_here
 TWITTER_API_SECRET=your_api_secret_here
 TWITTER_ACCESS_TOKEN=your_access_token_here
 TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret_here
-RSS_FEEDS=https://example.com/feed1.xml,https://example.com/feed2.xml
+NEWS_API_KEY=your_eventregistry_api_key_here
+NEWS_QUERY=SHA256 Bitcoin mining

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 python-dotenv
-feedparser
+eventregistry
 tweepy


### PR DESCRIPTION
## Summary
- replace RSS feed parsing with EventRegistry article queries
- add NEWS_API_KEY and NEWS_QUERY env variables
- remove feedparser dependency and add eventregistry

## Testing
- `python -m py_compile twitter_sha256_news_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde2c9af848329a27ae2a996689037