### PR TITLE
docs: document NewsAPI configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ TWITTER_API_KEY=your_api_key_here
 TWITTER_API_SECRET=your_api_secret_here
 TWITTER_ACCESS_TOKEN=your_access_token_here
 TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret_here
-NEWS_API_KEY=your_eventregistry_api_key_here
-NEWS_QUERY=SHA256 Bitcoin mining
+NEWS_API_KEY=your_newsapi_api_key_here
+NEWS_QUERY="SHA256 Bitcoin mining"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # twitter-bot
 # SHA256 News Twitter Bot
 
-This bot monitors RSS feeds for SHA256 Bitcoin mining news and tweets the latest headlines to Twitter.
+This bot uses NewsAPI's Python SDK to search for SHA256 Bitcoin mining news and tweets the latest headlines to Twitter.
 
 ## Features
 
-- Fetches SHA256 Bitcoin mining news from RSS feeds
+- Fetches SHA256 Bitcoin mining news via NewsAPI queries
 - Tweets headlines to a configured Twitter account
-- Securely loads Twitter API credentials from a `.env` file (not included in repo)
+- Securely loads Twitter and NewsAPI credentials from a `.env` file (not included in repo)
 
 ## Setup
 
@@ -17,8 +17,11 @@ This bot monitors RSS feeds for SHA256 Bitcoin mining news and tweets the latest
    cd YOUR-REPO
    ```
 
-2. **Create your `.env` file with Twitter API keys**  
-   (See `.env.example` for format.)
+2. **Create your `.env` file with Twitter API keys and NewsAPI settings**
+   Copy `.env.example` and fill in:
+   - `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`
+   - `NEWS_API_KEY`: your NewsAPI key
+   - `NEWS_QUERY`: search keywords for articles (e.g., `"SHA256 Bitcoin mining"`)
 
 3. **Install dependencies:**
    ```sh
@@ -29,6 +32,15 @@ This bot monitors RSS feeds for SHA256 Bitcoin mining news and tweets the latest
    ```sh
    python twitter_sha256_news_bot.py
    ```
+
+## NewsAPI usage example
+
+```python
+from newsapi import NewsApiClient
+
+newsapi = NewsApiClient(api_key=os.getenv("NEWS_API_KEY"))
+articles = newsapi.get_everything(q=os.getenv("NEWS_QUERY"))
+```
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- replace RSS references with NewsAPI configuration instructions
- add NEWS_API_KEY and NEWS_QUERY placeholders
- document NewsAPI usage example

## Testing
- `python -m py_compile twitter_sha256_news_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde3567ce08329a8cf0b20112938a6