### PR TITLE
Prevent duplicate tweets using persistent URL history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 __pycache__/
 *.pyc
+tweeted_articles.json

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This bot uses NewsAPI's Python SDK to search for SHA256 Bitcoin mining news and 
 
 - Fetches SHA256 Bitcoin mining news via NewsAPI queries
 - Tweets headlines to a configured Twitter account
+- Avoids posting the same article twice using a local history store
 - Securely loads Twitter and NewsAPI credentials from a `.env` file (not included in repo)
 
 ## Setup


### PR DESCRIPTION
## Summary
- store tweeted article URLs with timestamps in a JSON file
- skip tweeting if an article URL is already in the store
- remove stored URLs older than 7 days to keep the history small
- document duplicate protection in README and ignore history file

## Testing
- `python -m py_compile twitter_sha256_news_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde4b9b99483299bb3ea88c15b833d