### PR TITLE
Handle corrupt tweet store

### DIFF
--- a/tests/test_load_tweeted_articles.py
+++ b/tests/test_load_tweeted_articles.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_load_tweeted_articles_handles_invalid_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("TWITTER_API_KEY", "x")
+    monkeypatch.setenv("TWITTER_API_SECRET", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN_SECRET", "x")
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    bot = importlib.import_module("twitter_sha256_news_bot")
+
+    store = tmp_path / "tweeted_articles.json"
+    store.write_text("{invalid")
+    monkeypatch.setattr(bot, "STORE_FILE", str(store))
+
+    assert bot.load_tweeted_articles() == {}

--- a/twitter_sha256_news_bot.py
+++ b/twitter_sha256_news_bot.py
@@ -36,8 +36,11 @@ RETENTION_DAYS = 7
 
 def load_tweeted_articles():
     if os.path.exists(STORE_FILE):
-        with open(STORE_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
+        try:
+            with open(STORE_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
     return {}
 
 


### PR DESCRIPTION
## Summary
- Avoid crashing when the tweet history JSON is corrupted by returning an empty store instead
- Add regression test for loading a corrupted tweet history file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bde57bfbd48329b0632716749c03a5