### PR TITLE
docs: switch to eventregistry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ TWITTER_API_KEY=your_api_key_here
 TWITTER_API_SECRET=your_api_secret_here
 TWITTER_ACCESS_TOKEN=your_access_token_here
 TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret_here
-NEWS_API_KEY=your_newsapi_api_key_here
+NEWS_API_KEY=your_eventregistry_api_key_here
 NEWS_QUERY="SHA256 Bitcoin mining"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # twitter-bot
 # SHA256 News Twitter Bot
 
-This bot uses NewsAPI's Python SDK to search for SHA256 Bitcoin mining news and tweets the latest headlines to Twitter.
+This bot uses the EventRegistry API to search for SHA256 Bitcoin mining news and tweets the latest headlines to Twitter.
 
 ## Features
 
-- Fetches SHA256 Bitcoin mining news via NewsAPI queries
+- Fetches SHA256 Bitcoin mining news via EventRegistry queries
 - Tweets headlines to a configured Twitter account
 - Avoids posting the same article twice using a local history store
-- Securely loads Twitter and NewsAPI credentials from a `.env` file (not included in repo)
+- Securely loads Twitter and EventRegistry credentials from a `.env` file (not included in repo)
 
 ## Setup
 
@@ -18,10 +18,10 @@ This bot uses NewsAPI's Python SDK to search for SHA256 Bitcoin mining news and 
    cd YOUR-REPO
    ```
 
-2. **Create your `.env` file with Twitter API keys and NewsAPI settings**
+2. **Create your `.env` file with Twitter API keys and EventRegistry settings**
    Copy `.env.example` and fill in:
    - `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`
-   - `NEWS_API_KEY`: your NewsAPI key
+   - `NEWS_API_KEY`: your EventRegistry API key
    - `NEWS_QUERY`: search keywords for articles (e.g., `"SHA256 Bitcoin mining"`)
 
 3. **Install dependencies:**
@@ -34,13 +34,15 @@ This bot uses NewsAPI's Python SDK to search for SHA256 Bitcoin mining news and 
    python twitter_sha256_news_bot.py
    ```
 
-## NewsAPI usage example
+## EventRegistry usage example
 
 ```python
-from newsapi import NewsApiClient
+from eventregistry import EventRegistry, QueryArticlesIter, QueryItems
 
-newsapi = NewsApiClient(api_key=os.getenv("NEWS_API_KEY"))
-articles = newsapi.get_everything(q=os.getenv("NEWS_QUERY"))
+er = EventRegistry(apiKey=os.getenv("NEWS_API_KEY"))
+keywords = QueryItems.AND(os.getenv("NEWS_QUERY", "").split(","))
+for article in QueryArticlesIter(keywords=keywords).execQuery(er):
+    print(article["title"], article["url"])
 ```
 
 ## Deployment


### PR DESCRIPTION
## Summary
- replace NewsAPI references with EventRegistry
- document EventRegistry API key and sample usage

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde839ac4c8329974dd2bd641647a3