### PR TITLE
Handle store read errors

### DIFF
--- a/tests/test_load_tweeted_articles.py
+++ b/tests/test_load_tweeted_articles.py
@@ -17,3 +17,24 @@ def test_load_tweeted_articles_handles_invalid_json(monkeypatch, tmp_path):
     monkeypatch.setattr(bot, "STORE_FILE", str(store))
 
     assert bot.load_tweeted_articles() == {}
+
+
+def test_load_tweeted_articles_handles_oserror(monkeypatch, tmp_path):
+    monkeypatch.setenv("TWITTER_API_KEY", "x")
+    monkeypatch.setenv("TWITTER_API_SECRET", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN_SECRET", "x")
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    bot = importlib.import_module("twitter_sha256_news_bot")
+
+    store = tmp_path / "tweeted_articles.json"
+    store.write_text("{}")
+    monkeypatch.setattr(bot, "STORE_FILE", str(store))
+
+    def raise_oserror(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr("builtins.open", raise_oserror)
+
+    assert bot.load_tweeted_articles() == {}

--- a/twitter_sha256_news_bot.py
+++ b/twitter_sha256_news_bot.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import time
+import logging
 
 from eventregistry import EventRegistry, QueryArticlesIter, QueryItems
 import tweepy
@@ -39,7 +40,8 @@ def load_tweeted_articles():
         try:
             with open(STORE_FILE, "r", encoding="utf-8") as f:
                 return json.load(f)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, OSError) as e:
+            logging.warning("Failed to read store file: %s", e)
             return {}
     return {}
 


### PR DESCRIPTION
## Summary
- catch JSON and OS errors when loading the persisted tweet store
- warn and return empty when store read fails
- test that OSError from reading the store is handled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde84216c483299a887df2a4bdc890