### PR TITLE
Add tests for headline truncation and news retrieval

### DIFF
--- a/tests/test_cleanup_old_entries.py
+++ b/tests/test_cleanup_old_entries.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def import_bot(monkeypatch):
+    monkeypatch.setenv("TWITTER_API_KEY", "x")
+    monkeypatch.setenv("TWITTER_API_SECRET", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN_SECRET", "x")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    if "twitter_sha256_news_bot" in sys.modules:
+        del sys.modules["twitter_sha256_news_bot"]
+    return importlib.import_module("twitter_sha256_news_bot")
+
+
+def test_cleanup_old_entries(monkeypatch):
+    bot = import_bot(monkeypatch)
+    now = 1_000_000
+    monkeypatch.setattr(bot.time, "time", lambda: now)
+    threshold = now - bot.RETENTION_DAYS * 24 * 60 * 60
+    data = {
+        "http://old.com": threshold - 1,
+        "http://new.com": threshold + 1,
+    }
+    removed = bot.cleanup_old_entries(data)
+    assert removed == ["http://old.com"]
+    assert "http://old.com" not in data
+    assert "http://new.com" in data

--- a/tests/test_get_latest_headlines.py
+++ b/tests/test_get_latest_headlines.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def import_bot(monkeypatch):
+    monkeypatch.setenv("TWITTER_API_KEY", "x")
+    monkeypatch.setenv("TWITTER_API_SECRET", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN_SECRET", "x")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    if "twitter_sha256_news_bot" in sys.modules:
+        del sys.modules["twitter_sha256_news_bot"]
+    return importlib.import_module("twitter_sha256_news_bot")
+
+
+def test_get_latest_headlines(monkeypatch):
+    bot = import_bot(monkeypatch)
+
+    class DummyRegistry:
+        pass
+
+    class DummyQuery:
+        def __init__(self, keywords=None):
+            self.keywords = keywords
+
+        def execQuery(self, er):
+            return [
+                {"title": "Title 1", "url": "http://example.com/1"},
+                {"title": "Title 2", "url": "http://example.com/2"},
+                {"title": None, "url": "http://example.com/3"},
+            ]
+
+    class DummyItems:
+        @staticmethod
+        def AND(items):
+            return items
+
+    monkeypatch.setenv("NEWS_API_KEY", "key")
+    monkeypatch.setenv("NEWS_QUERY", "python,ai")
+    monkeypatch.setattr(bot, "EventRegistry", lambda apiKey=None: DummyRegistry())
+    monkeypatch.setattr(bot, "QueryArticlesIter", DummyQuery)
+    monkeypatch.setattr(bot, "QueryItems", DummyItems)
+
+    headlines = bot.get_latest_headlines()
+    assert headlines == [
+        ("Title 1", "http://example.com/1"),
+        ("Title 2", "http://example.com/2"),
+    ]

--- a/tests/test_truncate_headline.py
+++ b/tests/test_truncate_headline.py
@@ -1,0 +1,40 @@
+import importlib
+import re
+import sys
+from pathlib import Path
+
+
+def import_bot(monkeypatch):
+    monkeypatch.setenv("TWITTER_API_KEY", "x")
+    monkeypatch.setenv("TWITTER_API_SECRET", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN", "x")
+    monkeypatch.setenv("TWITTER_ACCESS_TOKEN_SECRET", "x")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    if "twitter_sha256_news_bot" in sys.modules:
+        del sys.modules["twitter_sha256_news_bot"]
+    return importlib.import_module("twitter_sha256_news_bot")
+
+
+def test_truncate_headline_accounts_for_url_length(monkeypatch):
+    bot = import_bot(monkeypatch)
+    long_text = "A" * 270
+    url = (
+        "https://example.com/this-is-a-very-long-url-that-exceeds-twitter-shortened-length"
+    )
+    headline = f"{long_text} {url}"
+    truncated = bot.truncate_headline(headline)
+    assert truncated == f"{'A' * 256} {url}"
+    urls = re.findall(r"https?://\S+", truncated)
+    effective_length = len(truncated) + sum(23 - len(u) for u in urls)
+    assert effective_length <= 280
+
+
+def test_truncate_headline_keeps_only_last_url(monkeypatch):
+    bot = import_bot(monkeypatch)
+    headline = "start http://one.com middle http://two.com"
+    result = bot.truncate_headline(headline, max_length=30)
+    assert "http://one.com" not in result
+    assert result.strip().endswith("http://two.com")
+    urls = re.findall(r"https?://\S+", result)
+    effective_length = len(result) + sum(23 - len(u) for u in urls)
+    assert effective_length <= 30


### PR DESCRIPTION
## Summary
- Add tests verifying `truncate_headline` respects t.co URL shortening and retains only the final URL
- Ensure `cleanup_old_entries` removes stale URLs while preserving recent ones
- Mock EventRegistry components to test `get_latest_headlines` without external calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde847721c8329819f67f7f8cd992b